### PR TITLE
Fix processing of empty slice.

### DIFF
--- a/tree/node.go
+++ b/tree/node.go
@@ -152,6 +152,11 @@ func (n *node) flatten(i interface{}) {
 		}
 	case []interface{}:
 		n.isCollection = true
+		if len(v) == 0 {
+			n.Value = v
+			break
+		}
+
 		for i, e := range v {
 			n.Add([]string{strconv.Itoa(i)}, e)
 		}

--- a/tree/node.go
+++ b/tree/node.go
@@ -147,6 +147,11 @@ func (n *node) flatten(i interface{}) {
 	switch v := i.(type) {
 	case map[string]interface{}:
 		n.isCollection = false
+		if len(v) == 0 {
+			n.Value = v
+			break
+		}
+
 		for k, e := range v {
 			n.Add([]string{k}, e)
 		}

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -90,6 +90,18 @@ func TestTree_Del(t *testing.T) {
 `,
 		},
 		{
+			name:    "empty map",
+			pattern: "data.*.password",
+			in: map[string]interface{}{
+				"data": map[string]interface{}{},
+			},
+			// but not
+			// ── data    <nil>
+			out: `
+└── data	map[]
+`,
+		},
+		{
 			name:    "plain",
 			pattern: "supu",
 			in: map[string]interface{}{

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -78,6 +78,18 @@ func TestTree_Del(t *testing.T) {
 `,
 		},
 		{
+			name:    "empty slice",
+			pattern: "data.*.password",
+			in: map[string]interface{}{
+				"data": []interface{}{},
+			},
+			// but not
+			// ── data	<nil>
+			out: `
+└── data	[]
+`,
+		},
+		{
 			name:    "plain",
 			pattern: "supu",
 			in: map[string]interface{}{


### PR DESCRIPTION
I'm krakend user and I faced with the next issue:
I had the next config:
```
"flatmap_filter": [
	{
	  "type": "del",
	  "args": [
	    "data.*.password"
	  ]
	}
]
```
And my backend returns the next response in some cases:
```
{
	"password": []
}
```
Then krakend converts it to the:
```
{
	"password": null
}
```
But I expect `"password": []`.

This PR should solve this issue.

